### PR TITLE
Wrap call with FH.init

### DIFF
--- a/iOS-Template-App/HomeViewController.m
+++ b/iOS-Template-App/HomeViewController.m
@@ -21,19 +21,29 @@
 }
 
 
+
 - (IBAction)cloudCall:(id)sender {
-  NSDictionary *args = [NSDictionary dictionaryWithObject:name.text forKey:@"hello"];
-  FHCloudRequest *req = (FHCloudRequest *) [FH buildCloudRequest:@"/hello" WithMethod:@"POST" AndHeaders:nil AndArgs:args];
-  
-  [req execAsyncWithSuccess:^(FHResponse * res) {
-    // Response
-    NSLog(@"Response: %@", res.rawResponseAsString);
-    result.text = [res.parsedResponse objectForKey:@"msg"];
-  } AndFailure:^(FHResponse * res){
-    // Errors
-    NSLog(@"Failed to call. Response = %@", res.rawResponseAsString);
-    result.text = res.rawResponseAsString;
-  }];
+    
+    [FH initWithSuccess:^(FHResponse *response) {
+        NSLog(@"initialized OK");
+        
+        NSDictionary *args = [NSDictionary dictionaryWithObject:name.text forKey:@"hello"];
+        FHCloudRequest *req = (FHCloudRequest *) [FH buildCloudRequest:@"/hello" WithMethod:@"POST" AndHeaders:nil AndArgs:args];
+        
+        [req execAsyncWithSuccess:^(FHResponse * res) {
+            // Response
+            NSLog(@"Response: %@", res.rawResponseAsString);
+            result.text = [res.parsedResponse objectForKey:@"msg"];
+        } AndFailure:^(FHResponse * res){
+            // Errors
+            NSLog(@"Failed to call. Response = %@", res.rawResponseAsString);
+            result.text = res.rawResponseAsString;
+        }];
+        
+    } AndFailure:^(FHResponse *response) {
+        NSLog(@"initialize fail, %@", response.rawResponseAsString);
+    }];
+    
 }
 
 @end


### PR DESCRIPTION
thisPR fix the issue we encounter when doing iOS9 test migration, making sure init is done successfully prior cloud call.